### PR TITLE
publish diagnostics message when not connected

### DIFF
--- a/game_controller_hl/game_controller_hl/receiver.py
+++ b/game_controller_hl/game_controller_hl/receiver.py
@@ -135,7 +135,7 @@ class GameStateReceiver(Node):
         except IOError as e:
                 self.get_logger().warn(f"Error while sending keep-alive: {str(e)}")
 
-    def publish_diagnostics(self, reiceved_message_lately: bool):
+    def publish_diagnostics(self, received_message_lately: bool):
         """ 
         This publishes a Diagnostics Array.
         """
@@ -146,7 +146,7 @@ class GameStateReceiver(Node):
 
         #configure DiagnosticStatus message
         diag = DiagnosticStatus(name = "Game Controller", hardware_id = "Game Controller" )
-        if not reiceved_message_lately:
+        if not received_message_lately:
             diag.message = "Lost connection to game controller for " + str(int(self.get_time_since_last_package().nanoseconds/1e9)) + " sec"
             diag.level = DiagnosticStatus.WARN
         else:

--- a/game_controller_hl/package.xml
+++ b/game_controller_hl/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <depend>diagnostic_msgs</depend>
   <depend>game_controller_hl_interfaces</depend>
   <depend>python3-construct</depend>
   <depend>rclpy</depend>


### PR DESCRIPTION
When the game controller is not connected we don't want to assume a state. Instead we just want to wait. Additionally we publish a diagnostics message so that we can see if we are connected and how long we are not connected.  